### PR TITLE
testing: allow to override the driver name at link time

### DIFF
--- a/sqlarfs/driver_modernc_test.go
+++ b/sqlarfs/driver_modernc_test.go
@@ -7,5 +7,7 @@ import (
 )
 
 func init() {
-	sqliteDriver = "sqlite"
+	if sqliteDriver == "" {
+		sqliteDriver = "sqlite"
+	}
 }

--- a/sqlarfs/driver_test.go
+++ b/sqlarfs/driver_test.go
@@ -5,5 +5,10 @@ package sqlarfs_test
 import _ "github.com/mattn/go-sqlite3"
 
 func init() {
-	sqliteDriver = "sqlite3"
+	// See https://github.com/mattn/go-sqlite3/blob/master/sqlite3.go#L237
+	// go test -v -ldflags="-X github.com/mattn/go-sqlite3.driverName=toto -X github.com/dolmen-go/sqlar/sqlarfs_test.sqliteDriver=toto" -run 'TestShowDriver$'
+
+	if sqliteDriver == "" {
+		sqliteDriver = "sqlite3"
+	}
 }


### PR DESCRIPTION
Example:
```console
$ go test -v -ldflags="-X github.com/mattn/go-sqlite3.driverName=toto -X github.com/dolmen-go/sqlar/sqlarfs_test.sqliteDriver=toto" -run 'TestShowDriver$'
=== RUN   TestShowDriver
    sqlarfs_test.go:19: toto
--- PASS: TestShowDriver (0.00s)
PASS
ok  	github.com/dolmen-go/sqlar/sqlarfs	0.374s
```